### PR TITLE
Pilight Steuerung

### DIFF
--- a/ended/available/pilight.sh
+++ b/ended/available/pilight.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Dieses Skript schaltet eine Funksteckdose (siehe Pilight Konfiguration)
+sudo pilight-send -S 127.0.0.1 -P 5000 -p elro_800_switch -s 31 -u 1 -f

--- a/started/available/pilight.sh
+++ b/started/available/pilight.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Dieses Skript schaltet eine Funksteckdose (siehe Pilight Konfiguration)
+sudo pilight-send -S 127.0.0.1 -P 5000 -p elro_800_switch -s 31 -u 1 -t


### PR DESCRIPTION
Ich habe den Bot bei mir mit Pilight kombiniert und dachte mir, dass das evtl. hilfreich sein könnte. Voraussetzung ist ein korrekt konfigurierter Pilight Daemon.

Damit kann man eine Funksteckdose via Pilight und einem entsprechenden Funkmodul am Pi steuern. Eine Anleitung dazu gibt es hier: http://www.heise.de/ct/ausgabe/2016-2-Funksteckdosen-und-mehr-mit-dem-Raspi-steuern-3057510.html
